### PR TITLE
Bump version number to 2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-helpers",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A collection of helpers and widgets for our JS front end applications",
   "main": "javascript-helpers.js",
   "scripts": {


### PR DESCRIPTION
There was a weird issue with gemfury where the latest commit had a version number of 2.4.1 - as a result version 2.7.0 on the gemfury repo doesn't have the new nav stuff, so I'm pushing 2.7.1 to fix it